### PR TITLE
TotC: Continue DialogueHelper when twin valkyr event is started.

### DIFF
--- a/scripts/northrend/crusaders_coliseum/trial_of_the_crusader/instance_trial_of_the_crusader.cpp
+++ b/scripts/northrend/crusaders_coliseum/trial_of_the_crusader/instance_trial_of_the_crusader.cpp
@@ -304,6 +304,7 @@ void instance_trial_of_the_crusader::SetData(uint32 uiType, uint32 uiData)
             {
                 if (Creature* pTirion = GetSingleCreatureFromStorage(NPC_TIRION_A))
                     DoScriptText(m_auiEncounter[uiType] != FAIL ? SAY_TIRION_TWINS_INTRO : SAY_RAID_INTRO_SHORT, pTirion);
+                StartNextDialogueText(TYPE_TWIN_VALKYR);
             }
             else if (uiData == FAIL)
             {


### PR DESCRIPTION
Currently you can talk to Barrett Ramsey to start the Twin Valkyr encounter, however the encounter never starts.
DialogueHelper has to be started when the uiData for TYPE_TWIN_VALKYR is set to SPECIAL.
