### PR TITLE
Simplify script naming and implement AutoScript class

### DIFF
--- a/ScriptMgr.cpp
+++ b/ScriptMgr.cpp
@@ -302,7 +302,7 @@ void DoOrSimulateScriptTextForMap(int32 iTextEntry, uint32 uiCreatureEntry, Map*
 
 void Script::RegisterSelf(bool bReportError)
 {
-    if (uint32 id = GetScriptId(Name.c_str()))
+    if (uint32 id = GetScriptId(Name))
     {
         m_scripts[id] = this;
         ++num_sc_scripts;
@@ -310,10 +310,30 @@ void Script::RegisterSelf(bool bReportError)
     else
     {
         if (bReportError)
-            script_error_log("Script registering but ScriptName %s is not assigned in database. Script will not be used.", Name.c_str());
+            script_error_log("Script registering but ScriptName %s is not assigned in database. Script will not be used.", Name);
 
         delete this;
     }
+}
+
+//*********************************
+//******** AutoScript *************
+
+Script* AutoScript::newScript(const char* scriptName, bool reportError/*=true*/)
+{
+    Register(); // register last added script (if any)
+
+    m_script = new Script(scriptName);
+    m_reportError = reportError;
+    return m_script;
+}
+
+void AutoScript::Register()
+{
+    if (!m_script)
+        return;
+    m_script->RegisterSelf(m_reportError);
+    m_script = NULL;
 }
 
 //********************************

--- a/ScriptMgr.h
+++ b/ScriptMgr.h
@@ -61,7 +61,7 @@ enum EscortFaction
 
 struct Script
 {
-    Script() :
+    Script(const char* scriptName = NULL) : Name(scriptName),
         pGossipHello(NULL), pGossipHelloGO(NULL), pGossipSelect(NULL), pGossipSelectGO(NULL),
         pGossipSelectWithCode(NULL), pGossipSelectGOWithCode(NULL),
         pDialogStatusNPC(NULL), pDialogStatusGO(NULL),
@@ -72,35 +72,60 @@ struct Script
         pEffectAuraDummy(NULL), GetAI(NULL), GetInstanceData(NULL)
     {}
 
-    std::string Name;
+    const char* Name;
 
-    bool (*pGossipHello)(Player*, Creature*);
-    bool (*pGossipHelloGO)(Player*, GameObject*);
-    bool (*pGossipSelect)(Player*, Creature*, uint32, uint32);
-    bool (*pGossipSelectGO)(Player*, GameObject*, uint32, uint32);
-    bool (*pGossipSelectWithCode)(Player*, Creature*, uint32, uint32, const char*);
-    bool (*pGossipSelectGOWithCode)(Player*, GameObject*, uint32, uint32, const char*);
-    uint32(*pDialogStatusNPC)(Player*, Creature*);
-    uint32(*pDialogStatusGO)(Player*, GameObject*);
-    bool (*pQuestAcceptNPC)(Player*, Creature*, Quest const*);
-    bool (*pQuestAcceptGO)(Player*, GameObject*, Quest const*);
-    bool (*pQuestAcceptItem)(Player*, Item*, Quest const*);
-    bool (*pQuestRewardedNPC)(Player*, Creature*, Quest const*);
-    bool (*pQuestRewardedGO)(Player*, GameObject*, Quest const*);
-    bool (*pGOUse)(Player*, GameObject*);
-    bool (*pItemUse)(Player*, Item*, SpellCastTargets const&);
-    bool (*pAreaTrigger)(Player*, AreaTriggerEntry const*);
-    bool (*pProcessEventId)(uint32, Object*, Object*, bool);
-    bool (*pEffectDummyNPC)(Unit*, uint32, SpellEffectIndex, Creature*);
-    bool (*pEffectDummyGO)(Unit*, uint32, SpellEffectIndex, GameObject*);
-    bool (*pEffectDummyItem)(Unit*, uint32, SpellEffectIndex, Item*);
-    bool (*pEffectScriptEffectNPC)(Unit*, uint32, SpellEffectIndex, Creature*);
-    bool (*pEffectAuraDummy)(const Aura*, bool);
+    bool (*pGossipHello             )(Player*, Creature*);
+    bool (*pGossipHelloGO           )(Player*, GameObject*);
+    bool (*pGossipSelect            )(Player*, Creature*, uint32, uint32);
+    bool (*pGossipSelectGO          )(Player*, GameObject*, uint32, uint32);
+    bool (*pGossipSelectWithCode    )(Player*, Creature*, uint32, uint32, const char*);
+    bool (*pGossipSelectGOWithCode  )(Player*, GameObject*, uint32, uint32, const char*);
+    uint32 (*pDialogStatusNPC       )(Player*, Creature*);
+    uint32 (*pDialogStatusGO        )(Player*, GameObject*);
+    bool (*pQuestAcceptNPC          )(Player*, Creature*, Quest const*);
+    bool (*pQuestAcceptGO           )(Player*, GameObject*, Quest const*);
+    bool (*pQuestAcceptItem         )(Player*, Item*, Quest const*);
+    bool (*pQuestRewardedNPC        )(Player*, Creature*, Quest const*);
+    bool (*pQuestRewardedGO         )(Player*, GameObject*, Quest const*);
+    bool (*pGOUse                   )(Player*, GameObject*);
+    bool (*pItemUse                 )(Player*, Item*, SpellCastTargets const&);
+    bool (*pAreaTrigger             )(Player*, AreaTriggerEntry const*);
+    bool (*pProcessEventId          )(uint32, Object*, Object*, bool);
+    bool (*pEffectDummyNPC          )(Unit*, uint32, SpellEffectIndex, Creature*);
+    bool (*pEffectDummyGO           )(Unit*, uint32, SpellEffectIndex, GameObject*);
+    bool (*pEffectDummyItem         )(Unit*, uint32, SpellEffectIndex, Item*);
+    bool (*pEffectScriptEffectNPC   )(Unit*, uint32, SpellEffectIndex, Creature*);
+    bool (*pEffectAuraDummy         )(const Aura*, bool);
 
-    CreatureAI* (*GetAI)(Creature*);
-    InstanceData* (*GetInstanceData)(Map*);
+    CreatureAI* (*GetAI             )(Creature*);
+    InstanceData* (*GetInstanceData )(Map*);
 
     void RegisterSelf(bool bReportError = true);
+};
+
+// *********************************************************
+// ******************* AutoScript **************************
+
+class AutoScript
+{
+    private:
+        Script* m_script;
+        bool m_reportError;
+
+        void Register();
+
+    public:
+        AutoScript() : m_script(NULL), m_reportError(true) {}
+        AutoScript(const char* scriptName, bool reportError = true) : m_script(NULL) { newScript(scriptName, reportError); }
+        ~AutoScript() { Register(); }
+
+        Script* newScript(const char* scriptName, bool reportError = true);
+
+        Script* operator -> ()
+        {
+            MANGOS_ASSERT(m_script != NULL && "AutoScript: use newScript() before!");
+            return m_script;
+        }
 };
 
 // *********************************************************

--- a/scripts/battlegrounds/battleground.cpp
+++ b/scripts/battlegrounds/battleground.cpp
@@ -104,11 +104,7 @@ CreatureAI* GetAI_npc_spirit_guide(Creature* pCreature)
 
 void AddSC_battleground()
 {
-    Script* pNewScript;
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_spirit_guide";
-    pNewScript->GetAI = &GetAI_npc_spirit_guide;
-    pNewScript->pGossipHello = &GossipHello_npc_spirit_guide;
-    pNewScript->RegisterSelf();
+    AutoScript s("npc_spirit_guide");
+    s->GetAI = &GetAI_npc_spirit_guide;
+    s->pGossipHello = &GossipHello_npc_spirit_guide;
 }

--- a/scripts/examples/example_creature.cpp
+++ b/scripts/examples/example_creature.cpp
@@ -280,12 +280,8 @@ bool GossipSelect_example_creature(Player* pPlayer, Creature* pCreature, uint32 
 // It must define all handled functions that are to be run in this script
 void AddSC_example_creature()
 {
-    Script* pNewScript;
-
-    pNewScript = new Script;
-    pNewScript->Name = "example_creature";
-    pNewScript->GetAI = &GetAI_example_creature;
-    pNewScript->pGossipHello = &GossipHello_example_creature;
-    pNewScript->pGossipSelect = &GossipSelect_example_creature;
-    pNewScript->RegisterSelf(false);
+    AutoScript s("example_creature", false);
+    s->GetAI = &GetAI_example_creature;
+    s->pGossipHello = &GossipHello_example_creature;
+    s->pGossipSelect = &GossipSelect_example_creature;
 }

--- a/scripts/examples/example_escort.cpp
+++ b/scripts/examples/example_escort.cpp
@@ -224,12 +224,8 @@ bool GossipSelect_example_escort(Player* pPlayer, Creature* pCreature, uint32 /*
 
 void AddSC_example_escort()
 {
-    Script* pNewScript;
-
-    pNewScript = new Script;
-    pNewScript->Name = "example_escort";
-    pNewScript->GetAI = &GetAI_example_escort;
-    pNewScript->pGossipHello = &GossipHello_example_escort;
-    pNewScript->pGossipSelect = &GossipSelect_example_escort;
-    pNewScript->RegisterSelf(false);
+    AutoScript s("example_escort", false);
+    s->GetAI = &GetAI_example_escort;
+    s->pGossipHello = &GossipHello_example_escort;
+    s->pGossipSelect = &GossipSelect_example_escort;
 }

--- a/scripts/examples/example_gossip_codebox.cpp
+++ b/scripts/examples/example_gossip_codebox.cpp
@@ -89,12 +89,8 @@ bool GossipSelectWithCode_example_gossip_codebox(Player* pPlayer, Creature* pCre
 
 void AddSC_example_gossip_codebox()
 {
-    Script* pNewScript;
-
-    pNewScript = new Script;
-    pNewScript->Name = "example_gossip_codebox";
-    pNewScript->pGossipHello = &GossipHello_example_gossip_codebox;
-    pNewScript->pGossipSelect = &GossipSelect_example_gossip_codebox;
-    pNewScript->pGossipSelectWithCode = &GossipSelectWithCode_example_gossip_codebox;
-    pNewScript->RegisterSelf(false);
+    AutoScript s("example_gossip_codebox", false);
+    s->pGossipHello = &GossipHello_example_gossip_codebox;
+    s->pGossipSelect = &GossipSelect_example_gossip_codebox;
+    s->pGossipSelectWithCode = &GossipSelectWithCode_example_gossip_codebox;
 }

--- a/scripts/examples/example_misc.cpp
+++ b/scripts/examples/example_misc.cpp
@@ -49,20 +49,14 @@ bool GOUse_example_go_teleporter(Player* pPlayer, GameObject* /*pGo*/)
 
 void AddSC_example_misc()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_example";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_example;
-    pNewScript->RegisterSelf(false);
+    s.newScript("at_example", false);
+    s->pAreaTrigger = &AreaTrigger_at_example;
 
-    pNewScript = new Script;
-    pNewScript->Name = "example_item";
-    pNewScript->pItemUse = &ItemUse_example_item;
-    pNewScript->RegisterSelf(false);
+    s.newScript("example_item", false);
+    s->pItemUse = &ItemUse_example_item;
 
-    pNewScript = new Script;
-    pNewScript->Name = "example_go_teleporter";
-    pNewScript->pGOUse = &GOUse_example_go_teleporter;
-    pNewScript->RegisterSelf(false);
+    s.newScript("example_go_teleporter", false);
+    s->pGOUse = &GOUse_example_go_teleporter;
 }

--- a/scripts/world/areatrigger_scripts.cpp
+++ b/scripts/world/areatrigger_scripts.cpp
@@ -325,60 +325,38 @@ bool AreaTrigger_at_murkdeep(Player* pPlayer, AreaTriggerEntry const* pAt)
 
 void AddSC_areatrigger_scripts()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_childrens_week_spot";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_childrens_week_spot;
-    pNewScript->RegisterSelf();
+    s.newScript("at_childrens_week_spot");
+    s->pAreaTrigger = &AreaTrigger_at_childrens_week_spot;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_aldurthar_gate";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_aldurthar_gate;
-    pNewScript->RegisterSelf();
+    s.newScript("at_aldurthar_gate");
+    s->pAreaTrigger = &AreaTrigger_at_aldurthar_gate;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_coilfang_waterfall";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_coilfang_waterfall;
-    pNewScript->RegisterSelf();
+    s.newScript("at_coilfang_waterfall");
+    s->pAreaTrigger = &AreaTrigger_at_coilfang_waterfall;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_legion_teleporter";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_legion_teleporter;
-    pNewScript->RegisterSelf();
+    s.newScript("at_legion_teleporter");
+    s->pAreaTrigger = &AreaTrigger_at_legion_teleporter;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_ravenholdt";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_ravenholdt;
-    pNewScript->RegisterSelf();
+    s.newScript("at_ravenholdt");
+    s->pAreaTrigger = &AreaTrigger_at_ravenholdt;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_spearborn_encampment";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_spearborn_encampment;
-    pNewScript->RegisterSelf();
+    s.newScript("at_spearborn_encampment");
+    s->pAreaTrigger = &AreaTrigger_at_spearborn_encampment;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_warsong_farms";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_warsong_farms;
-    pNewScript->RegisterSelf();
+    s.newScript("at_warsong_farms");
+    s->pAreaTrigger = &AreaTrigger_at_warsong_farms;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_waygate";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_waygate;
-    pNewScript->RegisterSelf();
+    s.newScript("at_waygate");
+    s->pAreaTrigger = &AreaTrigger_at_waygate;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_stormwright_shelf";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_stormwright_shelf;
-    pNewScript->RegisterSelf();
+    s.newScript("at_stormwright_shelf");
+    s->pAreaTrigger = &AreaTrigger_at_stormwright_shelf;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_scent_larkorwi";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_scent_larkorwi;
-    pNewScript->RegisterSelf();
+    s.newScript("at_scent_larkorwi");
+    s->pAreaTrigger = &AreaTrigger_at_scent_larkorwi;
 
-    pNewScript = new Script;
-    pNewScript->Name = "at_murkdeep";
-    pNewScript->pAreaTrigger = &AreaTrigger_at_murkdeep;
-    pNewScript->RegisterSelf();
+    s.newScript("at_murkdeep");
+    s->pAreaTrigger = &AreaTrigger_at_murkdeep;
 }

--- a/scripts/world/bosses_emerald_dragons.cpp
+++ b/scripts/world/bosses_emerald_dragons.cpp
@@ -608,40 +608,26 @@ CreatureAI* GetAI_mob_dementeddruids(Creature* pCreature)
 
 void AddSC_bosses_emerald_dragons()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "boss_emeriss";
-    pNewScript->GetAI = &GetAI_boss_emeriss;
-    pNewScript->RegisterSelf();
+    s.newScript("boss_emeriss");
+    s->GetAI = &GetAI_boss_emeriss;
 
-    pNewScript = new Script;
-    pNewScript->Name = "boss_lethon";
-    pNewScript->GetAI = &GetAI_boss_lethon;
-    pNewScript->RegisterSelf();
+    s.newScript("boss_lethon");
+    s->GetAI = &GetAI_boss_lethon;
 
-    pNewScript = new Script;
-    pNewScript->Name = "npc_spirit_shade";
-    pNewScript->GetAI = &GetAI_npc_spirit_shade;
-    pNewScript->RegisterSelf();
+    s.newScript("npc_spirit_shade");
+    s->GetAI = &GetAI_npc_spirit_shade;
 
-    pNewScript = new Script;
-    pNewScript->Name = "boss_taerar";
-    pNewScript->GetAI = &GetAI_boss_taerar;
-    pNewScript->RegisterSelf();
+    s.newScript("boss_taerar");
+    s->GetAI = &GetAI_boss_taerar;
 
-    pNewScript = new Script;
-    pNewScript->Name = "boss_shade_of_taerar";
-    pNewScript->GetAI = &GetAI_boss_shadeoftaerar;
-    pNewScript->RegisterSelf();
+    s.newScript("boss_shade_of_taerar");
+    s->GetAI = &GetAI_boss_shadeoftaerar;
 
-    pNewScript = new Script;
-    pNewScript->Name = "boss_ysondre";
-    pNewScript->GetAI = &GetAI_boss_ysondre;
-    pNewScript->RegisterSelf();
+    s.newScript("boss_ysondre");
+    s->GetAI = &GetAI_boss_ysondre;
 
-    pNewScript = new Script;
-    pNewScript->Name = "mob_dementeddruids";
-    pNewScript->GetAI = &GetAI_mob_dementeddruids;
-    pNewScript->RegisterSelf();
+    s.newScript("mob_dementeddruids");
+    s->GetAI = &GetAI_mob_dementeddruids;
 }

--- a/scripts/world/go_scripts.cpp
+++ b/scripts/world/go_scripts.cpp
@@ -358,60 +358,38 @@ bool GOUse_go_lab_work_reagents(Player* pPlayer, GameObject* pGo)
 
 void AddSC_go_scripts()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_barov_journal";
-    pNewScript->pGOUse =          &GOUse_go_barov_journal;
-    pNewScript->RegisterSelf();
+    s.newScript("go_barov_journal");
+    s->pGOUse = &GOUse_go_barov_journal;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_ethereum_prison";
-    pNewScript->pGOUse =          &GOUse_go_ethereum_prison;
-    pNewScript->RegisterSelf();
+    s.newScript("go_ethereum_prison");
+    s->pGOUse = &GOUse_go_ethereum_prison;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_ethereum_stasis";
-    pNewScript->pGOUse =          &GOUse_go_ethereum_stasis;
-    pNewScript->RegisterSelf();
+    s.newScript("go_ethereum_stasis");
+    s->pGOUse = &GOUse_go_ethereum_stasis;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_jump_a_tron";
-    pNewScript->pGOUse =          &GOUse_go_jump_a_tron;
-    pNewScript->RegisterSelf();
+    s.newScript("go_jump_a_tron");
+    s->pGOUse = &GOUse_go_jump_a_tron;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_mysterious_snow_mound";
-    pNewScript->pGOUse =          &GOUse_go_mysterious_snow_mound;
-    pNewScript->RegisterSelf();
+    s.newScript("go_mysterious_snow_mound");
+    s->pGOUse = &GOUse_go_mysterious_snow_mound;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_shrine_of_the_birds";
-    pNewScript->pGOUse =          &GOUse_go_shrine_of_the_birds;
-    pNewScript->RegisterSelf();
+    s.newScript("go_shrine_of_the_birds");
+    s->pGOUse = &GOUse_go_shrine_of_the_birds;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_tele_to_dalaran_crystal";
-    pNewScript->pGOUse =          &GOUse_go_tele_to_dalaran_crystal;
-    pNewScript->RegisterSelf();
+    s.newScript("go_tele_to_dalaran_crystal");
+    s->pGOUse = &GOUse_go_tele_to_dalaran_crystal;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_tele_to_violet_stand";
-    pNewScript->pGOUse =          &GOUse_go_tele_to_violet_stand;
-    pNewScript->RegisterSelf();
+    s.newScript("go_tele_to_violet_stand");
+    s->pGOUse = &GOUse_go_tele_to_violet_stand;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_andorhal_tower";
-    pNewScript->pGOUse =          &GOUse_go_andorhal_tower;
-    pNewScript->RegisterSelf();
+    s.newScript("go_andorhal_tower");
+    s->pGOUse = &GOUse_go_andorhal_tower;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_scourge_enclosure";
-    pNewScript->pGOUse =          &GOUse_go_scourge_enclosure;
-    pNewScript->RegisterSelf();
+    s.newScript("go_scourge_enclosure");
+    s->pGOUse = &GOUse_go_scourge_enclosure;
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_lab_work_reagents";
-    pNewScript->pGOUse =          &GOUse_go_lab_work_reagents;
-    pNewScript->RegisterSelf();
+    s.newScript("go_lab_work_reagents");
+    s->pGOUse = &GOUse_go_lab_work_reagents;
 }

--- a/scripts/world/guards.cpp
+++ b/scripts/world/guards.cpp
@@ -273,105 +273,65 @@ CreatureAI* GetAI_guard_undercity(Creature* pCreature)
 
 void AddSC_guards()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_azuremyst";
-    pNewScript->GetAI = &GetAI_guard_azuremyst;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_azuremyst");
+    s->GetAI = &GetAI_guard_azuremyst;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_bluffwatcher";
-    pNewScript->GetAI = &GetAI_guard_bluffwatcher;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_bluffwatcher");
+    s->GetAI = &GetAI_guard_bluffwatcher;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_contested";
-    pNewScript->GetAI = &GetAI_guard_contested;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_contested");
+    s->GetAI = &GetAI_guard_contested;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_darnassus";
-    pNewScript->GetAI = &GetAI_guard_darnassus;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_darnassus");
+    s->GetAI = &GetAI_guard_darnassus;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_dunmorogh";
-    pNewScript->GetAI = &GetAI_guard_dunmorogh;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_dunmorogh");
+    s->GetAI = &GetAI_guard_dunmorogh;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_durotar";
-    pNewScript->GetAI = &GetAI_guard_durotar;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_durotar");
+    s->GetAI = &GetAI_guard_durotar;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_elwynnforest";
-    pNewScript->GetAI = &GetAI_guard_elwynnforest;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_elwynnforest");
+    s->GetAI = &GetAI_guard_elwynnforest;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_eversong";
-    pNewScript->GetAI = &GetAI_guard_eversong;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_eversong");
+    s->GetAI = &GetAI_guard_eversong;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_exodar";
-    pNewScript->GetAI = &GetAI_guard_exodar;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_exodar");
+    s->GetAI = &GetAI_guard_exodar;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_ironforge";
-    pNewScript->GetAI = &GetAI_guard_ironforge;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_ironforge");
+    s->GetAI = &GetAI_guard_ironforge;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_mulgore";
-    pNewScript->GetAI = &GetAI_guard_mulgore;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_mulgore");
+    s->GetAI = &GetAI_guard_mulgore;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_orgrimmar";
-    pNewScript->GetAI = &GetAI_guard_orgrimmar;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_orgrimmar");
+    s->GetAI = &GetAI_guard_orgrimmar;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_shattrath";
-    pNewScript->GetAI = &GetAI_guard_shattrath;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_shattrath");
+    s->GetAI = &GetAI_guard_shattrath;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_shattrath_aldor";
-    pNewScript->GetAI = &GetAI_guard_shattrath_aldor;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_shattrath_aldor");
+    s->GetAI = &GetAI_guard_shattrath_aldor;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_shattrath_scryer";
-    pNewScript->GetAI = &GetAI_guard_shattrath_scryer;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_shattrath_scryer");
+    s->GetAI = &GetAI_guard_shattrath_scryer;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_silvermoon";
-    pNewScript->GetAI = &GetAI_guard_silvermoon;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_silvermoon");
+    s->GetAI = &GetAI_guard_silvermoon;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_stormwind";
-    pNewScript->GetAI = &GetAI_guard_stormwind;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_stormwind");
+    s->GetAI = &GetAI_guard_stormwind;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_teldrassil";
-    pNewScript->GetAI = &GetAI_guard_teldrassil;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_teldrassil");
+    s->GetAI = &GetAI_guard_teldrassil;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_tirisfal";
-    pNewScript->GetAI = &GetAI_guard_tirisfal;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_tirisfal");
+    s->GetAI = &GetAI_guard_tirisfal;
 
-    pNewScript = new Script;
-    pNewScript->Name = "guard_undercity";
-    pNewScript->GetAI = &GetAI_guard_undercity;
-    pNewScript->RegisterSelf();
+    s.newScript("guard_undercity");
+    s->GetAI = &GetAI_guard_undercity;
 }

--- a/scripts/world/item_scripts.cpp
+++ b/scripts/world/item_scripts.cpp
@@ -129,25 +129,17 @@ bool ItemUse_item_petrov_cluster_bombs(Player* pPlayer, Item* pItem, const Spell
 
 void AddSC_item_scripts()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "item_arcane_charges";
-    pNewScript->pItemUse = &ItemUse_item_arcane_charges;
-    pNewScript->RegisterSelf();
+    s.newScript("item_arcane_charges");
+    s->pItemUse = &ItemUse_item_arcane_charges;
 
-    pNewScript = new Script;
-    pNewScript->Name = "item_flying_machine";
-    pNewScript->pItemUse = &ItemUse_item_flying_machine;
-    pNewScript->RegisterSelf();
+    s.newScript("item_flying_machine");
+    s->pItemUse = &ItemUse_item_flying_machine;
 
-    pNewScript = new Script;
-    pNewScript->Name = "item_gor_dreks_ointment";
-    pNewScript->pItemUse = &ItemUse_item_gor_dreks_ointment;
-    pNewScript->RegisterSelf();
+    s.newScript("item_gor_dreks_ointment");
+    s->pItemUse = &ItemUse_item_gor_dreks_ointment;
 
-    pNewScript = new Script;
-    pNewScript->Name = "item_petrov_cluster_bombs";
-    pNewScript->pItemUse = &ItemUse_item_petrov_cluster_bombs;
-    pNewScript->RegisterSelf();
+    s.newScript("item_petrov_cluster_bombs");
+    s->pItemUse = &ItemUse_item_petrov_cluster_bombs;
 }

--- a/scripts/world/mob_generic_creature.cpp
+++ b/scripts/world/mob_generic_creature.cpp
@@ -165,10 +165,5 @@ CreatureAI* GetAI_generic_creature(Creature* pCreature)
 
 void AddSC_generic_creature()
 {
-    Script* pNewScript;
-
-    pNewScript = new Script;
-    pNewScript->Name = "generic_creature";
-    pNewScript->GetAI = &GetAI_generic_creature;
-    pNewScript->RegisterSelf(false);
+    AutoScript("generic_creature", false)->GetAI = &GetAI_generic_creature;
 }

--- a/scripts/world/npc_professions.cpp
+++ b/scripts/world/npc_professions.cpp
@@ -1199,35 +1199,25 @@ bool GossipSelect_npc_prof_tailor(Player* pPlayer, Creature* pCreature, uint32 u
 
 void AddSC_npc_professions()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "npc_prof_alchemy";
-    pNewScript->pGossipHello =  &GossipHello_npc_prof_alchemy;
-    pNewScript->pGossipSelect = &GossipSelect_npc_prof_alchemy;
-    pNewScript->RegisterSelf();
+    s.newScript("npc_prof_alchemy");
+    s->pGossipHello =  &GossipHello_npc_prof_alchemy;
+    s->pGossipSelect = &GossipSelect_npc_prof_alchemy;
 
-    pNewScript = new Script;
-    pNewScript->Name = "npc_prof_blacksmith";
-    pNewScript->pGossipHello =  &GossipHello_npc_prof_blacksmith;
-    pNewScript->pGossipSelect = &GossipSelect_npc_prof_blacksmith;
-    pNewScript->RegisterSelf();
+    s.newScript("npc_prof_blacksmith");
+    s->pGossipHello =  &GossipHello_npc_prof_blacksmith;
+    s->pGossipSelect = &GossipSelect_npc_prof_blacksmith;
 
-    pNewScript = new Script;
-    pNewScript->Name = "npc_prof_leather";
-    pNewScript->pGossipHello =  &GossipHello_npc_prof_leather;
-    pNewScript->pGossipSelect = &GossipSelect_npc_prof_leather;
-    pNewScript->RegisterSelf();
+    s.newScript("npc_prof_leather");
+    s->pGossipHello =  &GossipHello_npc_prof_leather;
+    s->pGossipSelect = &GossipSelect_npc_prof_leather;
 
-    pNewScript = new Script;
-    pNewScript->Name = "npc_prof_tailor";
-    pNewScript->pGossipHello =  &GossipHello_npc_prof_tailor;
-    pNewScript->pGossipSelect = &GossipSelect_npc_prof_tailor;
-    pNewScript->RegisterSelf();
+    s.newScript("npc_prof_tailor");
+    s->pGossipHello =  &GossipHello_npc_prof_tailor;
+    s->pGossipSelect = &GossipSelect_npc_prof_tailor;
 
-    /*pNewScript = new Script;
-    pNewScript->Name = "go_soothsaying_for_dummies";
-    pNewScript->pGOUse =  &GOUse_go_soothsaying_for_dummies;
-    // pNewScript->pGossipSelect = &GossipSelect_go_soothsaying_for_dummies;
-    pNewScript->RegisterSelf();*/
+    /*s.newScript("go_soothsaying_for_dummies");
+    s->pGOUse =  &GOUse_go_soothsaying_for_dummies;
+    // s->pGossipSelect = &GossipSelect_go_soothsaying_for_dummies;*/
 }

--- a/scripts/world/npcs_special.cpp
+++ b/scripts/world/npcs_special.cpp
@@ -1743,78 +1743,53 @@ bool EffectDummyCreature_npc_redemption_target(Unit* pCaster, uint32 uiSpellId, 
 
 void AddSC_npcs_special()
 {
-    Script* pNewScript;
+    AutoScript s;
+
+    s.newScript("npc_air_force_bots");
+    s->GetAI = &GetAI_npc_air_force_bots;
+
+    s.newScript("npc_chicken_cluck");
+    s->GetAI = &GetAI_npc_chicken_cluck;
+    s->pQuestAcceptNPC = &QuestAccept_npc_chicken_cluck;
+    s->pQuestRewardedNPC = &QuestRewarded_npc_chicken_cluck;
+
+    s.newScript("npc_dancing_flames");
+    s->GetAI = &GetAI_npc_dancing_flames;
+
+    s.newScript("npc_injured_patient");
+    s->GetAI = &GetAI_npc_injured_patient;
+
+    s.newScript("npc_doctor");
+    s->GetAI = &GetAI_npc_doctor;
+    s->pQuestAcceptNPC = &QuestAccept_npc_doctor;
+
+    s.newScript("npc_garments_of_quests");
+    s->GetAI = &GetAI_npc_garments_of_quests;
+
+    s.newScript("npc_guardian");
+    s->GetAI = &GetAI_npc_guardian;
+
+    s.newScript("npc_innkeeper", false);  // script and error report disabled, but script can be used for custom needs, adding ScriptName
+    s->pGossipHello = &GossipHello_npc_innkeeper;
+    s->pGossipSelect = &GossipSelect_npc_innkeeper;
+
+    s.newScript("npc_mount_vendor");
+    s->pGossipHello = &GossipHello_npc_mount_vendor;
+    s->pGossipSelect = &GossipSelect_npc_mount_vendor;
+
+    s.newScript("npc_sayge");
+    s->pGossipHello = &GossipHello_npc_sayge;
+    s->pGossipSelect = &GossipSelect_npc_sayge;
+
+    s.newScript("npc_tabard_vendor");
+    s->pGossipHello = &GossipHello_npc_tabard_vendor;
+    s->pGossipSelect = &GossipSelect_npc_tabard_vendor;
+
+    s.newScript("npc_spring_rabbit");
+    s->GetAI = &GetAI_npc_spring_rabbit;
 
     pNewScript = new Script;
-    pNewScript->Name = "npc_air_force_bots";
-    pNewScript->GetAI = &GetAI_npc_air_force_bots;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_chicken_cluck";
-    pNewScript->GetAI = &GetAI_npc_chicken_cluck;
-    pNewScript->pQuestAcceptNPC =   &QuestAccept_npc_chicken_cluck;
-    pNewScript->pQuestRewardedNPC = &QuestRewarded_npc_chicken_cluck;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_dancing_flames";
-    pNewScript->GetAI = &GetAI_npc_dancing_flames;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_injured_patient";
-    pNewScript->GetAI = &GetAI_npc_injured_patient;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_doctor";
-    pNewScript->GetAI = &GetAI_npc_doctor;
-    pNewScript->pQuestAcceptNPC = &QuestAccept_npc_doctor;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_garments_of_quests";
-    pNewScript->GetAI = &GetAI_npc_garments_of_quests;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_guardian";
-    pNewScript->GetAI = &GetAI_npc_guardian;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_innkeeper";
-    pNewScript->pGossipHello = &GossipHello_npc_innkeeper;
-    pNewScript->pGossipSelect = &GossipSelect_npc_innkeeper;
-    pNewScript->RegisterSelf(false);                        // script and error report disabled, but script can be used for custom needs, adding ScriptName
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_mount_vendor";
-    pNewScript->pGossipHello =  &GossipHello_npc_mount_vendor;
-    pNewScript->pGossipSelect = &GossipSelect_npc_mount_vendor;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_sayge";
-    pNewScript->pGossipHello = &GossipHello_npc_sayge;
-    pNewScript->pGossipSelect = &GossipSelect_npc_sayge;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_tabard_vendor";
-    pNewScript->pGossipHello =  &GossipHello_npc_tabard_vendor;
-    pNewScript->pGossipSelect = &GossipSelect_npc_tabard_vendor;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_spring_rabbit";
-    pNewScript->GetAI = &GetAI_npc_spring_rabbit;
-    pNewScript->RegisterSelf();
-
-    pNewScript = new Script;
-    pNewScript->Name = "npc_redemption_target";
-    pNewScript->GetAI = &GetAI_npc_redemption_target;
-    pNewScript->pEffectDummyNPC = &EffectDummyCreature_npc_redemption_target;
-    pNewScript->RegisterSelf();
+    s.newScript("npc_redemption_target");
+    s->GetAI = &GetAI_npc_redemption_target;
+    s->pEffectDummyNPC = &EffectDummyCreature_npc_redemption_target;
 }

--- a/scripts/world/spell_scripts.cpp
+++ b/scripts/world/spell_scripts.cpp
@@ -1045,16 +1045,12 @@ bool EffectDummyCreature_spell_dummy_npc(Unit* pCaster, uint32 uiSpellId, SpellE
 
 void AddSC_spell_scripts()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "spell_dummy_go";
-    pNewScript->pEffectDummyGO = &EffectDummyGameObj_spell_dummy_go;
-    pNewScript->RegisterSelf();
+    s.newScript("spell_dummy_go");
+    s->pEffectDummyGO = &EffectDummyGameObj_spell_dummy_go;
 
-    pNewScript = new Script;
-    pNewScript->Name = "spell_dummy_npc";
-    pNewScript->pEffectDummyNPC = &EffectDummyCreature_spell_dummy_npc;
-    pNewScript->pEffectAuraDummy = &EffectAuraDummy_spell_aura_dummy_npc;
-    pNewScript->RegisterSelf();
+    s.newScript("spell_dummy_npc");
+    s->pEffectDummyNPC = &EffectDummyCreature_spell_dummy_npc;
+    s->pEffectAuraDummy = &EffectAuraDummy_spell_aura_dummy_npc;
 }

--- a/scripts/world/world_map_scripts.cpp
+++ b/scripts/world/world_map_scripts.cpp
@@ -201,25 +201,17 @@ InstanceData* GetInstanceData_world_map_northrend(Map* pMap)
 
 void AddSC_world_map_scripts()
 {
-    Script* pNewScript;
+    AutoScript s;
 
-    pNewScript = new Script;
-    pNewScript->Name = "world_map_eastern_kingdoms";
-    pNewScript->GetInstanceData = &GetInstanceData_world_map_eastern_kingdoms;
-    pNewScript->RegisterSelf();
+    s.newScript("world_map_eastern_kingdoms");
+    s->GetInstanceData = &GetInstanceData_world_map_eastern_kingdoms;
 
-    pNewScript = new Script;
-    pNewScript->Name = "world_map_kalimdor";
-    pNewScript->GetInstanceData = &GetInstanceData_world_map_kalimdor;
-    pNewScript->RegisterSelf();
+    s.newScript("world_map_kalimdor");
+    s->GetInstanceData = &GetInstanceData_world_map_kalimdor;
 
-    pNewScript = new Script;
-    pNewScript->Name = "world_map_outland";
-    pNewScript->GetInstanceData = &GetInstanceData_world_map_outland;
-    pNewScript->RegisterSelf();
+    s.newScript("world_map_outland");
+    s->GetInstanceData = &GetInstanceData_world_map_outland;
 
-    pNewScript = new Script;
-    pNewScript->Name = "world_map_northrend";
-    pNewScript->GetInstanceData = &GetInstanceData_world_map_northrend;
-    pNewScript->RegisterSelf();
+    s.newScript("world_map_northrend");
+    s->GetInstanceData = &GetInstanceData_world_map_northrend;
 }


### PR DESCRIPTION
Full backward compatibility, old code will work without any changes.
This just a wrapper for an Script object, simplifies the code.

Usage examples:

AutoScript("script_name")->GetAI = &GetAI_realization;

**
AutoScript s("script_name");
s->pGossipHello = &GossipHello_realization;
s->pGossipSelect = &GossipSelect_realization;

**
AutoScript s;
s.newScript("script_name_1")->GetAI = &GetAI_realization_1;
s.newScript("script_name_2")->GetAI = &GetAI_realization_2;

**
AutoScript s;

s.newScript("script_name_1");
s->GetAI = &GetAI_script_name_1;

s.newScript("script_name_2");
s->GetAI = &GetAI_script_name_2;
