### PR TITLE
Some improvements to the Archaedas encounter in Uldaman.

### DIFF
--- a/scripts/eastern_kingdoms/uldaman/boss_archaedas.cpp
+++ b/scripts/eastern_kingdoms/uldaman/boss_archaedas.cpp
@@ -37,7 +37,8 @@ enum
     SAY_AGGRO                       = -1070001,
     SAY_AWAKE_GUARDIANS             = -1070002,
     SAY_AWAKE_WARDERS               = -1070003,
-    SAY_UNIT_SLAIN                  = -1070004
+    SAY_UNIT_SLAIN                  = -1070004,
+    EMOTE_BREAKS_FREE               = -1070005
 };
 
 struct MANGOS_DLL_DECL boss_archaedasAI : public ScriptedAI
@@ -97,9 +98,9 @@ struct MANGOS_DLL_DECL boss_archaedasAI : public ScriptedAI
     {
         if (pTarget->GetTypeId() != TYPEID_PLAYER)
         {
-            if (pTarget->HasAura(SPELL_STONED, EFFECT_INDEX_0))
+            if (pTarget->HasAura(SPELL_FREEZE_ANIM, EFFECT_INDEX_0))
             {
-                pTarget->RemoveAurasDueToSpell(SPELL_STONED);
+                pTarget->RemoveAurasDueToSpell(SPELL_FREEZE_ANIM);
 
                 if (Unit* pUnit = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
                 {
@@ -126,12 +127,18 @@ struct MANGOS_DLL_DECL boss_archaedasAI : public ScriptedAI
                 {
                     case 0:
                         DoCastSpellIfCan(m_creature, SPELL_ARCHAEDAS_AWAKEN_VISUAL);
+                        m_uiAwakeningTimer = 2000;
                         break;
                     case 1:
-                        DoScriptText(SAY_AGGRO, m_creature, NULL);
-                        m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                        DoScriptText(EMOTE_BREAKS_FREE, m_creature);
+                        m_uiAwakeningTimer = 3000;
                         break;
                     case 2:
+                        DoScriptText(SAY_AGGRO, m_creature, NULL);
+                        m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                        m_uiAwakeningTimer = 5000;
+                        break;
+                    case 3:
                         if (Player* pPlayer = m_creature->GetMap()->GetPlayer(m_pInstance->GetGuid(DATA_EVENT_STARTER)))
                             AttackStart(pPlayer);
                         else
@@ -142,7 +149,6 @@ struct MANGOS_DLL_DECL boss_archaedasAI : public ScriptedAI
                 }
 
                 ++m_uiSubevent;
-                m_uiAwakeningTimer = 5000;
             }
             else
                 m_uiAwakeningTimer -= uiDiff;

--- a/scripts/eastern_kingdoms/uldaman/instance_uldaman.cpp
+++ b/scripts/eastern_kingdoms/uldaman/instance_uldaman.cpp
@@ -53,6 +53,10 @@ void instance_uldaman::OnObjectCreate(GameObject* pGo)
             if (m_auiEncounter[1] == DONE)
                 pGo->SetGoState(GO_STATE_ACTIVE);
             break;
+        case GO_ANCIENT_TREASURE:
+            // We need to store this in m_mGoEntryGuidStore so
+            // we can spawn it later using DoRespawnGameObject.
+            break;
         default:
             return;
     }
@@ -116,6 +120,7 @@ void instance_uldaman::SetData(uint32 uiType, uint32 uiData)
                         pWarden->ForcedDespawn();
                 }
                 DoUseDoorOrButton(GO_ANCIENT_VAULT);
+                DoRespawnGameObject(GO_ANCIENT_TREASURE, HOUR);
             }
             m_auiEncounter[1] = uiData;
             break;

--- a/scripts/eastern_kingdoms/uldaman/uldaman.h
+++ b/scripts/eastern_kingdoms/uldaman/uldaman.h
@@ -16,6 +16,7 @@ enum
     GO_TEMPLE_DOOR_UPPER        = 124367,
     GO_TEMPLE_DOOR_LOWER        = 141869,
     GO_ANCIENT_VAULT            = 124369,
+    GO_ANCIENT_TREASURE         = 141979,
 
     NPC_CUSTODIAN               = 7309,
     NPC_HALLSHAPER              = 7077,
@@ -28,6 +29,7 @@ enum
     PHASE_ARCHA_3               = 3,
 
     SPELL_STONED                = 10255,
+    SPELL_FREEZE_ANIM           = 16245,
 
     EVENT_ID_ALTAR_KEEPER       = 2228,                     // spell 11568
     EVENT_ID_ALTAR_ARCHAEDAS    = 2268                      // spell 10340

--- a/sql/scriptdev2_script_full.sql
+++ b/sql/scriptdev2_script_full.sql
@@ -1063,7 +1063,8 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,commen
 (-1070001,'Who dares awaken Archaedas? Who dares the wrath of the makers!',5855,1,0,0,'archaedas SAY_AGGRO'),
 (-1070002,'Awake ye servants, defend the discs!',5856,1,0,0,'archaedas SAY_AWAKE_GUARDIANS'),
 (-1070003,'To my side, brothers. For the makers!',5857,1,0,0,'archaedas SAY_AWAKE_WARDERS'),
-(-1070004,'Reckless mortal.',5858,1,0,0,'archaedas SAY_UNIT_SLAIN');
+(-1070004,'Reckless mortal.',5858,1,0,0,'archaedas SAY_UNIT_SLAIN'),
+(-1070005,'%s breaks free from his stone slumber!',0,2,0,0,'archaedas EMOTE_BREAK_FREE');
 
 -- -1 090 000 GNOMEREGAN
 INSERT INTO script_texts (entry,content_default,sound,type,language,emote,comment) VALUES

--- a/sql/updates/r9000_scriptdev2.sql
+++ b/sql/updates/r9000_scriptdev2.sql
@@ -1,0 +1,3 @@
+DELETE FROM script_texts WHERE entry = -1070005;
+INSERT INTO script_texts (entry, content_default, sound, type, language, emote, comment) VALUES
+(-1070005,'%s breaks free from his stone slumber!', 0, 2, 0, 0, 'archaedas EMOTE_BREAK_FREE');


### PR DESCRIPTION
- Spawn the Ancient Treasure chest when the boss dies.
- Correct the aura spell to be removed when he awakes.
- Add emote when he awakes.

My sniffs tell me the aura that makes him look frozen is not the one the script was expecting (that's the one for all the little adds). 

Suggested TBC-DB update for those willing to test (submitted to be in the next update pack):

``` sql
-- Archaedas has identical data in both creature_addon and creature_template_addon.
-- Remove the first in favor of the second.
DELETE FROM creature_addon WHERE guid = 33537;

-- Archaedas is missing an aura to make him look like a statue initially.
UPDATE creature_template_addon SET auras = '16245' WHERE entry = 2748;

-- Add missing spawn for the Ancient Treasure, but initially despawned.
-- Defeating Archaedas should spawn the object.
-- Note: the position data is obviously from sniffs, but the 1 hour despawn
--       timer is guesswork and in sync with other dungeon chests.
DELETE FROM gameobject WHERE id = 141979;
INSERT INTO gameobject (guid, id, map, spawnMask, position_x, position_y, position_z, orientation, rotation0, rotation1, rotation2, rotation3, spawntimesecs, animprogress, state) VALUES
(101391, 141979, 70, 1, 153.39, 289.091, -52.2262, 2.68781, 0, 0, 0, 0, -3600, 255, 1);
```
