### PR TITLE
BRD - Vault Improvements

### DIFF
--- a/scripts/eastern_kingdoms/blackrock_depths/blackrock_depths.h
+++ b/scripts/eastern_kingdoms/blackrock_depths/blackrock_depths.h
@@ -66,6 +66,7 @@ enum
     GO_CHEST_SEVEN          = 169243,
     GO_ARENA_SPOILS         = 181074,
     GO_SECRET_DOOR          = 174553,
+    GO_SECRET_SAFE          = 161495,
 
     // Jail break event related
     GO_JAIL_DOOR_SUPPLY     = 170561,

--- a/scripts/eastern_kingdoms/blackrock_depths/instance_blackrock_depths.cpp
+++ b/scripts/eastern_kingdoms/blackrock_depths/instance_blackrock_depths.cpp
@@ -102,6 +102,7 @@ void instance_blackrock_depths::OnObjectCreate(GameObject* pGo)
         case GO_CHEST_SEVEN:
         case GO_ARENA_SPOILS:
         case GO_SECRET_DOOR:
+        case GO_SECRET_SAFE:
         case GO_JAIL_DOOR_SUPPLY:
         case GO_JAIL_SUPPLY_CRATE:
         case GO_DWARFRUNE_A01:
@@ -158,7 +159,10 @@ void instance_blackrock_depths::SetData(uint32 uiType, uint32 uiData)
                 return;
             }
             if (uiData == DONE)
+            {
                 DoUseDoorOrButton(GO_SECRET_DOOR);
+                DoToggleGameObjectFlags(GO_SECRET_SAFE, GO_FLAG_NO_INTERACT, false);
+            }
             m_auiEncounter[1] = uiData;
             break;
         case TYPE_BAR:


### PR DESCRIPTION
* Locked GOs in the vault are not selectable by default, to prevent abuse.
  This flag is removed as soon as they should become accessible.