### PR TITLE
Improve BRD arena event

### DIFF
--- a/scripts/eastern_kingdoms/blackrock_depths/blackrock_depths.h
+++ b/scripts/eastern_kingdoms/blackrock_depths/blackrock_depths.h
@@ -44,6 +44,15 @@ enum
     NPC_TOBIAS              = 9679,
     NPC_DUGHAL              = 9022,
 
+    // Arena crowd
+    NPC_ARENA_SPECTATOR     = 8916,
+    NPC_SHADOWFORGE_PEASANT = 8896,
+    NPC_SHADOWFORGE_CITIZEN = 8902,
+    NPC_SHADOWFORGE_SENATOR = 8904,
+    NPC_ANVILRAGE_SOLDIER   = 8893,
+    NPC_ANVILRAGE_MEDIC     = 8894,
+    NPC_ANVILRAGE_OFFICER   = 8895,
+
     GO_ARENA_1              = 161525,
     GO_ARENA_2              = 161522,
     GO_ARENA_3              = 161524,
@@ -87,7 +96,19 @@ enum
     SPELL_STONED            = 10255,                        // Aura of Warbringer Constructs in Relict Vault
 
     FACTION_DWARF_HOSTILE   = 754,                          // Hostile faction for the Tomb of the Seven dwarfs
+    FACTION_ARENA_NEUTRAL   = 674,                          // Neutral faction for NPC in top of Arena after event complete
 };
+
+struct Cylinder
+{
+    float m_fCenterX;
+    float m_fCenterY;
+    float m_fCenterZ;
+    uint32 m_uiRadius;
+    uint32 m_uiHeight;
+};
+
+static const Cylinder aArenaCrowdVolume[] = {595.78f, -188.65f, -38.63f, 69, 10};
 
 enum ArenaNPCs
 {
@@ -175,6 +196,7 @@ class instance_blackrock_depths : public ScriptedInstance
         float m_fArenaCenterX, m_fArenaCenterY, m_fArenaCenterZ;
 
         GuidSet m_sVaultNpcGuids;
+        GuidSet m_sArenaCrowdNpcGuids;
 };
 
 #endif

--- a/scripts/eastern_kingdoms/blackrock_depths/instance_blackrock_depths.cpp
+++ b/scripts/eastern_kingdoms/blackrock_depths/instance_blackrock_depths.cpp
@@ -78,6 +78,17 @@ void instance_blackrock_depths::OnCreatureCreate(Creature* pCreature)
         case NPC_WATCHER_DOOMGRIP:
             m_sVaultNpcGuids.insert(pCreature->GetObjectGuid());
             break;
+        // Arena crowd
+        case NPC_ARENA_SPECTATOR:
+        case NPC_SHADOWFORGE_PEASANT:
+        case NPC_SHADOWFORGE_CITIZEN:
+        case NPC_SHADOWFORGE_SENATOR:
+        case NPC_ANVILRAGE_SOLDIER:
+        case NPC_ANVILRAGE_MEDIC:
+        case NPC_ANVILRAGE_OFFICER:
+            if (std::abs(pCreature->GetPositionZ() < aArenaCrowdVolume->m_fCenterZ) || std::abs(pCreature->GetPositionZ() > aArenaCrowdVolume->m_fCenterZ + aArenaCrowdVolume->m_uiHeight) || !pCreature->IsWithinDist2d(aArenaCrowdVolume->m_fCenterX, aArenaCrowdVolume->m_fCenterY, aArenaCrowdVolume->m_uiRadius))
+                break;
+            m_sArenaCrowdNpcGuids.insert(pCreature->GetObjectGuid());
     }
 }
 
@@ -132,6 +143,17 @@ void instance_blackrock_depths::SetData(uint32 uiType, uint32 uiData)
             // If finished the arena event after theldren fight
             if (uiData == DONE && m_auiEncounter[0] == SPECIAL)
                 DoRespawnGameObject(GO_ARENA_SPOILS, HOUR);
+            else if (uiData == DONE)
+            {
+                for (GuidSet::const_iterator itr = m_sArenaCrowdNpcGuids.begin(); itr != m_sArenaCrowdNpcGuids.end(); ++itr)
+                {
+                    Creature* pSpectator = NULL;
+
+                    pSpectator = instance->GetCreature(*itr);
+                    if (pSpectator)
+                        pSpectator->SetFactionTemporary(FACTION_ARENA_NEUTRAL, TEMPFACTION_RESTORE_RESPAWN);
+                }
+            }
             m_auiEncounter[0] = uiData;
             break;
         case TYPE_VAULT:


### PR DESCRIPTION
Now the crowd of spectators will turn neutral once the arena event is defeated