### PR TITLE
Improve BRD Arena event (last part)

### DIFF
--- a/scripts/eastern_kingdoms/blackrock_depths/blackrock_depths.h
+++ b/scripts/eastern_kingdoms/blackrock_depths/blackrock_depths.h
@@ -96,7 +96,7 @@ enum
     SPELL_STONED            = 10255,                        // Aura of Warbringer Constructs in Relict Vault
 
     FACTION_DWARF_HOSTILE   = 754,                          // Hostile faction for the Tomb of the Seven dwarfs
-    FACTION_ARENA_NEUTRAL   = 674,                          // Neutral faction for NPC in top of Arena after event complete
+    FACTION_ARENA_NEUTRAL   = 15,                           // Neutral faction for NPC in top of Arena after event complete
 };
 
 struct ArenaCylinder
@@ -179,6 +179,7 @@ class instance_blackrock_depths : public ScriptedInstance
         // Arena Event
         void SetArenaCenterCoords(float fX, float fY, float fZ) { m_fArenaCenterX = fX; m_fArenaCenterY = fY; m_fArenaCenterZ = fZ; }
         void GetArenaCenterCoords(float& fX, float& fY, float& fZ) { fX = m_fArenaCenterX; fY = m_fArenaCenterY; fZ = m_fArenaCenterZ; }
+        GuidSet GetArenaCrowdGuid() { return m_sArenaCrowdNpcGuids; }
 
     private:
         void DoCallNextDwarf();

--- a/sql/scriptdev2_script_full.sql
+++ b/sql/scriptdev2_script_full.sql
@@ -1545,12 +1545,12 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,commen
 (-1230002,'Hail to the king, baby!',0,1,0,0,'dagran SAY_SLAY'),
 (-1230003,'You have challenged the Seven, and now you will die!',0,0,0,0,'doomrel SAY_DOOMREL_START_EVENT'),
 
-(-1230004,'The Sons of Thaurissan shall watch you perish in the Ring of the Law!',0,1,0,0,'grimstone SAY_START_1'),
-(-1230005,'You have been sentenced to death for crimes against the Dark Iron Nation!',0,1,0,0,'grimstone SAY_START_2'),
-(-1230006,'Unleash the fury and let it be done!',0,1,0,0,'grimstone SAY_OPEN_EAST_GATE'),
-(-1230007,'But your real punishment lies ahead.',0,1,0,0,'grimstone SAY_SUMMON_BOSS_1'),
-(-1230008,'Haha! I bet you thought you were done!',0,1,0,0,'grimstone SAY_SUMMON_BOSS_2'),
-(-1230009,'Good Riddance!',0,1,0,0,'grimstone SAY_OPEN_NORTH_GATE'),
+(-1230004,'The Sons of Thaurissan shall watch you perish in the Ring of the Law!',0,1,0,5,'grimstone SAY_START_1'),
+(-1230005,'You have been sentenced to death for crimes against the Dark Iron Nation!',0,1,0,25,'grimstone SAY_START_2'),
+(-1230006,'Unleash the fury and let it be done!',0,1,0,15,'grimstone SAY_OPEN_EAST_GATE'),
+(-1230007,'But your real punishment lies ahead.',0,1,0,1,'grimstone SAY_SUMMON_BOSS_1'),
+(-1230008,'Haha! I bet you thought you were done!',0,1,0,153,'grimstone SAY_SUMMON_BOSS_2'),
+(-1230009,'Good Riddance!',0,1,0,5,'grimstone SAY_OPEN_NORTH_GATE'),
 
 (-1230010,'Thank you, $N! I\'m free!!!',0,0,0,0,'dughal SAY_FREE'),
 (-1230011,'You locked up the wrong Marshal, $N. Prepare to be destroyed!',0,0,0,0,'windsor SAY_AGGRO_1'),

--- a/sql/updates/r3xxx_scriptdev2.sql
+++ b/sql/updates/r3xxx_scriptdev2.sql
@@ -1,0 +1,6 @@
+UPDATE `script_texts` SET `emote` = 25 WHERE `entry` = -1230005;
+UPDATE `script_texts` SET `emote` = 5 WHERE `entry` = -1230004;
+UPDATE `script_texts` SET `emote` = 15 WHERE `entry` = -1230006;
+UPDATE `script_texts` SET `emote` = 153 WHERE `entry` = -1230008;
+UPDATE `script_texts` SET `emote` = 1 WHERE `entry` = -1230007;
+UPDATE `script_texts` SET `emote` = 5 WHERE `entry` = -1230009;


### PR DESCRIPTION
* Cosmetic changes in BRD Arena event:
- All texts for High Justice Grimstone are now in and in the right order
- Emotes for High Justice Grimstone are now in
- High Justice Grimstone will now cast his visual spell when
spawning/despawning
- Gate opening visual spells are now in
- Some of the arena spectators now cheers at event start
* Fixes temporary faction ID for arena spectators from previous commit

Data come from official data. Results are close to what is visible in:
https://www.youtube.com/watch?v=w965TeVu56w